### PR TITLE
Add circleci status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MusicManager
 
+[![CircleCI](https://circleci.com/gh/arnawldo/music_manager.svg?style=svg)](https://circleci.com/gh/arnawldo/music_manager)
+
 To start your Phoenix server:
 
   * Install dependencies with `mix deps.get`


### PR DESCRIPTION
Add `CircleCI` status badge for runs on the default branch, currently develop.